### PR TITLE
fix: handle read file or create new directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -128,12 +128,14 @@ function createChangelog() {
     `All notable changes to ${major}.${minor}.x version will be documented in this file.`
   )
 
-  if (fs.existsSync(targetFile)) {
-    changelog = parser(fs.readFileSync(targetFile, 'utf-8'))
-  } else {
+  if (!fs.existsSync(ROOT_DIR)) {
     fs.mkdir(ROOT_DIR, (err) => {
       if (err) throw new Error(`Error write file: ${err.message}`)
     })
+  }
+
+  if (fs.existsSync(targetFile)) {
+    changelog = parser(fs.readFileSync(targetFile, 'utf-8'))
   }
 
   const release = new Release(bump.version, bump.date)


### PR DESCRIPTION
Separate read file and create new directory. Reason: create ROOT_DIR directory only and if only it does not exist